### PR TITLE
[INFRA-240] auto-restart SLAPD

### DIFF
--- a/manifests/cucumber.pp
+++ b/manifests/cucumber.pp
@@ -30,6 +30,11 @@ node default {
       'copy jira logs from eggplant to save space' :
         command => 'cd /var/log/apache2/issues.jenkins-ci.org && ./pull.sh',
         minute  => 10;
+
+      'restart slapd daily to pick up SSL certificate change automatically (INFRA-240)' :
+        command => '/etc/init.d/slapd restart',
+        hour    => 20;
+        minute  => 0;
     }
 
     package {


### PR DESCRIPTION
To feed a new SSL certificate automatically to LDAP daemon, just
auto-restart it every day. The time chosen is the off-business hour for
America and Europe.